### PR TITLE
chore: setup .claude folder with authorship attribution

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "commit": "Co-authored-by: Claude <noreply@anthropic.com>",
+    "pr": "Co-authored-by: Claude <noreply@anthropic.com>"
+  }
+}


### PR DESCRIPTION
Sets up the `.claude` folder with `settings.json` to configure Aven0xx as the primary author and Claude as co-author on all commits and PRs.