### PR TITLE
Fix userdata saves and align permissions

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -11,7 +11,7 @@ This file provides guidance for Claude Code/ChatGPT Codex when working in this r
 
 ## Project Overview
 
-**Velto** is a lightweight Minecraft core plugin (alpha) targeting Paper/Spigot/Bukkit servers. It is intentionally minimal — no economy, warps, kits, claims, towns, or minigame systems. The goal is a plug-and-play core that plays well with other plugins.
+**Velto** is a lightweight Minecraft core plugin (alpha) targeting Paper/Spigot/Bukkit servers. It is intentionally minimal — no economy, warps, towns, or minigame systems. The goal is a plug-and-play core that plays well with other plugins with every command that can be disabled.
 
 - Current version: `0.7.5-SNAPSHOT`
 - Supported MC versions: 1.21.4–1.21.11 (1.21.4 is LTS)

--- a/Guidelines.md
+++ b/Guidelines.md
@@ -11,9 +11,9 @@ This file provides guidance for Claude Code/ChatGPT Codex when working in this r
 
 ## Project Overview
 
-**Velto** is a lightweight Minecraft core plugin (alpha) targeting Paper/Spigot/Bukkit servers. It is intentionally minimal — no economy, homes, or warps. The goal is a plug-and-play core that plays well with other plugins.
+**Velto** is a lightweight Minecraft core plugin (alpha) targeting Paper/Spigot/Bukkit servers. It is intentionally minimal — no economy, warps, kits, claims, towns, or minigame systems. The goal is a plug-and-play core that plays well with other plugins.
 
-- Current version: `0.7.2-SNAPSHOT`
+- Current version: `0.7.5-SNAPSHOT`
 - Supported MC versions: 1.21.4–1.21.11 (1.21.4 is LTS)
 - Java package root: `com.aven0x`
 
@@ -69,4 +69,4 @@ Do NOT run `./gradlew build` at the root — it is intentionally blocked.
 
 ## What Velto Intentionally Excludes
 
-Do not add: economy, homes, TPA, warps, kits, claims, towns, or minigame systems. These are left to dedicated plugins by design.
+Do not add: economy, warps, kits, claims, towns, or minigame systems. These are left to dedicated plugins by design.

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -21,7 +21,10 @@ permissions:
       velto.craft: true
       velto.lore: true
       velto.alert: true
+      velto.tp: true
+      velto.tp.others: true
       velto.tpall: true
+      velto.tpa: true
       velto.sudo: true
       velto.notiftest: true
       velto.timeset: true
@@ -46,3 +49,7 @@ permissions:
       velto.gamemode.spectator.others: true
       velto.afk.list: true
       velto.afk.others: true
+      velto.home: true
+      velto.sethome: true
+      velto.delhome: true
+      velto.homes: true

--- a/common/src/main/java/com/aven0x/Velto/commands/TpaDenyCommand.java
+++ b/common/src/main/java/com/aven0x/Velto/commands/TpaDenyCommand.java
@@ -44,7 +44,7 @@ public class TpaDenyCommand extends BaseCommand {
         TpaManager.cancelRequest(request.requester());
 
         LangUtil.send(target, "tpa-denied-target",
-                Map.of("%requester%", requester != null ? requester.getName() : args[0]));
+                Map.of("%requester%", requester != null ? requester.getName() : request.requesterName()));
         if (requester != null && requester.isOnline()) {
             LangUtil.send(requester, "tpa-denied-requester", Map.of("%target%", target.getName()));
         }

--- a/common/src/main/java/com/aven0x/Velto/managers/TpaManager.java
+++ b/common/src/main/java/com/aven0x/Velto/managers/TpaManager.java
@@ -13,7 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class TpaManager {
 
-    public record TpaRequest(UUID requester, UUID target, long expiresAt) {}
+    public record TpaRequest(UUID requester, String requesterName, UUID target, long expiresAt) {}
 
     // One outgoing request per requester at a time.
     private static final Map<UUID, TpaRequest> pending = new ConcurrentHashMap<>();
@@ -23,7 +23,7 @@ public class TpaManager {
         cancelRequest(requester.getUniqueId());
 
         long expiresAt = System.currentTimeMillis() + ConfigUtil.getTpaExpireSeconds() * 1000L;
-        pending.put(requester.getUniqueId(), new TpaRequest(requester.getUniqueId(), target.getUniqueId(), expiresAt));
+        pending.put(requester.getUniqueId(), new TpaRequest(requester.getUniqueId(), requester.getName(), target.getUniqueId(), expiresAt));
 
         Bukkit.getScheduler().runTaskLater(VeltoPlugin.get(), () -> {
             TpaRequest req = pending.get(requester.getUniqueId());

--- a/common/src/main/java/com/aven0x/Velto/managers/UserdataManager.java
+++ b/common/src/main/java/com/aven0x/Velto/managers/UserdataManager.java
@@ -18,10 +18,20 @@ public final class UserdataManager {
     private UserdataManager() {}
 
     private static final Map<UUID, YamlConfiguration> cache = new ConcurrentHashMap<>();
+    private static final Map<UUID, PendingSave> pendingSaves = new ConcurrentHashMap<>();
     private static File userdataFolder;
     private static Logger logger;
     private static volatile boolean initialized = false;
     private static BukkitTask autosaveTask = null;
+
+    private static final class PendingSave {
+        YamlConfiguration snapshot;
+        boolean running;
+
+        PendingSave(YamlConfiguration snapshot) {
+            this.snapshot = snapshot;
+        }
+    }
 
     public static void init(File dataFolder) {
         logger = VeltoPlugin.get().getLogger();
@@ -87,15 +97,7 @@ public final class UserdataManager {
         if (yaml == null) return;
 
         YamlConfiguration snapshot = copyOf(yaml);
-        File target = fileFor(uuid);
-
-        VeltoPlugin.get().getServer().getScheduler().runTaskAsynchronously(VeltoPlugin.get(), () -> {
-            try {
-                snapshot.save(target);
-            } catch (IOException e) {
-                logger.log(Level.SEVERE, "[Velto] Failed to save userdata for " + uuid, e);
-            }
-        });
+        enqueueSave(uuid, snapshot);
     }
 
     public static void startAutosave(long intervalTicks) {
@@ -104,11 +106,7 @@ public final class UserdataManager {
                 .runTaskTimerAsynchronously(VeltoPlugin.get(), () -> {
                     for (Map.Entry<UUID, YamlConfiguration> entry : cache.entrySet()) {
                         YamlConfiguration snapshot = copyOf(entry.getValue());
-                        try {
-                            snapshot.save(fileFor(entry.getKey()));
-                        } catch (IOException e) {
-                            logger.log(Level.SEVERE, "[Velto] Autosave failed for " + entry.getKey(), e);
-                        }
+                        enqueueSave(entry.getKey(), snapshot);
                     }
                 }, intervalTicks, intervalTicks);
     }
@@ -126,6 +124,7 @@ public final class UserdataManager {
         for (Map.Entry<UUID, YamlConfiguration> entry : cache.entrySet()) {
             try {
                 entry.getValue().save(fileFor(entry.getKey()));
+                pendingSaves.remove(entry.getKey());
             } catch (IOException e) {
                 logger.log(Level.SEVERE, "[Velto] Failed to save userdata for " + entry.getKey() + " on shutdown", e);
             }
@@ -136,6 +135,63 @@ public final class UserdataManager {
 
     private static File fileFor(UUID uuid) {
         return new File(userdataFolder, uuid.toString() + ".yml");
+    }
+
+    private static void enqueueSave(UUID uuid, YamlConfiguration snapshot) {
+        PendingSave save = pendingSaves.compute(uuid, (ignored, existing) -> {
+            if (existing == null) return new PendingSave(snapshot);
+            synchronized (existing) {
+                existing.snapshot = snapshot;
+            }
+            return existing;
+        });
+
+        boolean shouldStart;
+        synchronized (save) {
+            shouldStart = !save.running;
+            if (shouldStart) save.running = true;
+        }
+
+        if (shouldStart) {
+            runNextSave(uuid, save);
+        }
+    }
+
+    private static void runNextSave(UUID uuid, PendingSave save) {
+        YamlConfiguration snapshot;
+        synchronized (save) {
+            snapshot = save.snapshot;
+            save.snapshot = null;
+        }
+
+        if (snapshot == null) {
+            boolean hasMore;
+            synchronized (save) {
+                hasMore = save.snapshot != null;
+                save.running = hasMore;
+            }
+            if (hasMore) {
+                runNextSave(uuid, save);
+            } else {
+                pendingSaves.remove(uuid, save);
+            }
+            return;
+        }
+
+        File target = fileFor(uuid);
+        YamlConfiguration finalSnapshot = snapshot;
+
+        VeltoPlugin.get().getServer().getScheduler().runTaskAsynchronously(VeltoPlugin.get(), () -> {
+            try {
+                if (pendingSaves.get(uuid) == save) {
+                    finalSnapshot.save(target);
+                }
+            } catch (IOException e) {
+                logger.log(Level.SEVERE, "[Velto] Failed to save userdata for " + uuid, e);
+            } finally {
+                runNextSave(uuid, save);
+            }
+        });
     }
 
     private static YamlConfiguration copyOf(YamlConfiguration source) {

--- a/paper/src/main/resources/paper-plugin.yml
+++ b/paper/src/main/resources/paper-plugin.yml
@@ -25,7 +25,10 @@ permissions:
       velto.craft: true
       velto.lore: true
       velto.alert: true
+      velto.tp: true
+      velto.tp.others: true
       velto.tpall: true
+      velto.tpa: true
       velto.sudo: true
       velto.notiftest: true
       velto.timeset: true
@@ -51,3 +54,7 @@ permissions:
       velto.afk.list: true
       velto.afk.others: true
       velto.anvil: true
+      velto.home: true
+      velto.sethome: true
+      velto.delhome: true
+      velto.homes: true


### PR DESCRIPTION
## Summary

- Serialize userdata saves per player UUID so older async snapshots cannot overwrite newer state.
- Keep TPA requester names in pending requests so `/tpadeny` works after the requester disconnects.
- Add missing command permissions to `velto.*` for Bukkit and Paper descriptors.
- Update `Guidelines.md` to match the current project version and feature scope.

## Impact

This prevents userdata regressions around homes and other per-player data when saves overlap, fixes a possible `/tpadeny` runtime crash, and makes wildcard admin permissions match the commands currently implemented.

## Validation

- `./gradlew :bukkit:build`
- `./gradlew :paper:build`
- `git diff --check`