### PR TITLE
Thread-safety & async improvements: chat formatting, teleports, userdata, and TPA permissions

### DIFF
--- a/bukkit/src/main/java/com/aven0x/VeltoBukkit/managers/ChatManager.java
+++ b/bukkit/src/main/java/com/aven0x/VeltoBukkit/managers/ChatManager.java
@@ -17,6 +17,8 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -35,14 +37,23 @@ public class ChatManager implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onChat(AsyncPlayerChatEvent event) {
         Player player = event.getPlayer();
+        String rawMessage = event.getMessage();
 
-        if (AtMentionHandler.handle(player, event.getMessage())) {
+        if (isAtMentionMessage(rawMessage)) {
             event.setCancelled(true);
+            runSync(() -> AtMentionHandler.handle(player, rawMessage));
             return;
         }
 
-        String format = resolveChatFormat(player);
+        String format = callSync(() -> buildChatFormat(player, rawMessage), CC.translate(ConfigUtil.getChatFormat())
+                .replace("%player_name%", player.getName())
+                .replace("%message%", rawMessage.replace("%", "%%")));
 
+        event.setFormat(format);
+    }
+
+    private String buildChatFormat(Player player, String rawMessage) {
+        String format = resolveChatFormat(player);
         format = format.replace("%player_name%", player.getName());
 
         if (papiAvailable) {
@@ -50,12 +61,42 @@ public class ChatManager implements Listener {
             if (resolved != null) format = resolved;
         }
 
-        String safeMessage = event.getMessage().replace("%", "%%");
+        String safeMessage = rawMessage.replace("%", "%%");
         format = format.replace("%message%", safeMessage);
+        return CC.translate(format);
+    }
 
-        format = CC.translate(format);
+    private boolean isAtMentionMessage(String message) {
+        if (!message.startsWith("@")) return false;
+        int space = message.indexOf(' ');
+        return space > 1 && !message.substring(space + 1).trim().isEmpty();
+    }
 
-        event.setFormat(format);
+    private void runSync(Runnable runnable) {
+        if (Bukkit.isPrimaryThread()) {
+            runnable.run();
+            return;
+        }
+
+        Bukkit.getScheduler().runTask(plugin, runnable);
+    }
+
+    private <T> T callSync(Callable<T> callable, T fallback) {
+        if (Bukkit.isPrimaryThread()) {
+            try {
+                return callable.call();
+            } catch (Exception e) {
+                plugin.getLogger().warning("[Velto] Failed to build chat format: " + e.getMessage());
+                return fallback;
+            }
+        }
+
+        try {
+            return Bukkit.getScheduler().callSyncMethod(plugin, callable).get(2, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            plugin.getLogger().warning("[Velto] Timed out while building chat format: " + e.getMessage());
+            return fallback;
+        }
     }
 
     private String resolveChatFormat(Player player) {

--- a/bukkit/src/main/resources/commands.yml
+++ b/bukkit/src/main/resources/commands.yml
@@ -124,9 +124,13 @@ tpa:
 tpaaccept:
   enabled: true
   aliases: ["tpaccept"]
+  permissions:
+    velto.tpa: velto.tpa
 tpadeny:
   enabled: true
   aliases: ["tpdeny"]
+  permissions:
+    velto.tpa: velto.tpa
 sudo:
   enabled: true
   aliases: []

--- a/common/src/main/java/com/aven0x/Velto/commands/ReloadCommand.java
+++ b/common/src/main/java/com/aven0x/Velto/commands/ReloadCommand.java
@@ -1,5 +1,6 @@
 package com.aven0x.Velto.commands;
 
+import com.aven0x.Velto.utils.CommandUtil;
 import com.aven0x.Velto.utils.ConfigUtil;
 import com.aven0x.Velto.utils.LangUtil;
 import org.bukkit.Bukkit;
@@ -33,6 +34,14 @@ public class ReloadCommand extends BaseCommand {
             Bukkit.getLogger().info("[Velto] lang.yml reloaded.");
         } catch (Throwable t) {
             Bukkit.getLogger().severe("[Velto] Failed to reload lang.yml: " + t.getMessage());
+            t.printStackTrace();
+        }
+
+        try {
+            CommandUtil.load();
+            Bukkit.getLogger().info("[Velto] commands.yml reloaded.");
+        } catch (Throwable t) {
+            Bukkit.getLogger().severe("[Velto] Failed to reload commands.yml: " + t.getMessage());
             t.printStackTrace();
         }
 

--- a/common/src/main/java/com/aven0x/Velto/commands/TpaAcceptCommand.java
+++ b/common/src/main/java/com/aven0x/Velto/commands/TpaAcceptCommand.java
@@ -20,6 +20,7 @@ public class TpaAcceptCommand extends BaseCommand {
     @Override
     public boolean execute(CommandSender sender, String label, String[] args) {
         if (!isPlayer(sender)) return true;
+        if (!hasPermission(sender, "velto.tpa")) return true;
 
         Player target = (Player) sender;
         TpaRequest request;

--- a/common/src/main/java/com/aven0x/Velto/commands/TpaDenyCommand.java
+++ b/common/src/main/java/com/aven0x/Velto/commands/TpaDenyCommand.java
@@ -19,6 +19,7 @@ public class TpaDenyCommand extends BaseCommand {
     @Override
     public boolean execute(CommandSender sender, String label, String[] args) {
         if (!isPlayer(sender)) return true;
+        if (!hasPermission(sender, "velto.tpa")) return true;
 
         Player target = (Player) sender;
         TpaRequest request;

--- a/common/src/main/java/com/aven0x/Velto/managers/TeleportManager.java
+++ b/common/src/main/java/com/aven0x/Velto/managers/TeleportManager.java
@@ -10,8 +10,10 @@ import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 
+import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class TeleportManager {
@@ -32,16 +34,15 @@ public class TeleportManager {
         teleport(player, location, null);
     }
 
-    // Player-initiated teleport with an optional callback executed the moment
-    // the actual teleport fires (end of countdown or instant when delay == 0).
+    // Player-initiated teleport with an optional callback executed after the
+    // teleport completes successfully.
     public void teleport(Player player, Location location, Runnable onComplete) {
         cancelPending(player);
 
         int seconds = resolveCountdown(player);
 
         if (seconds <= 0) {
-            teleportAsync(player, location);
-            if (onComplete != null) onComplete.run();
+            teleportAsync(player, location).thenAccept(success -> runCompletion(player, success, onComplete));
             return;
         }
 
@@ -68,8 +69,7 @@ public class TeleportManager {
                 if (remaining <= 0) {
                     pendingTeleports.remove(player.getUniqueId());
                     this.cancel();
-                    teleportAsync(player, location);
-                    if (onComplete != null) onComplete.run();
+                    teleportAsync(player, location).thenAccept(success -> runCompletion(player, success, onComplete));
                     return;
                 }
 
@@ -82,17 +82,20 @@ public class TeleportManager {
     }
 
     // System/admin teleport: bypasses countdown entirely (AFK zone, /tpall, etc.)
-    public void teleportAsync(Player player, Location location) {
+    public CompletableFuture<Boolean> teleportAsync(Player player, Location location) {
         if (ServerUtil.isPaper()) {
             try {
-                player.getClass().getMethod("teleportAsync", Location.class).invoke(player, location);
+                Method method = player.getClass().getMethod("teleportAsync", Location.class);
+                Object result = method.invoke(player, location);
+                if (result instanceof CompletableFuture<?> future) {
+                    return future.thenApply(Boolean.class::cast);
+                }
             } catch (Exception e) {
                 Bukkit.getLogger().warning("[Velto] teleportAsync failed on Paper, falling back to sync chunk load: " + e.getMessage());
-                bukkitTeleport(player, location);
             }
-        } else {
-            bukkitTeleport(player, location);
         }
+
+        return CompletableFuture.completedFuture(bukkitTeleport(player, location));
     }
 
     // Cancels any pending countdown for the given player.
@@ -101,9 +104,23 @@ public class TeleportManager {
         if (task != null) task.cancel();
     }
 
-    private void bukkitTeleport(Player player, Location location) {
+    private boolean bukkitTeleport(Player player, Location location) {
+        if (location.getWorld() == null) return false;
         location.getWorld().getChunkAt(location);
-        player.teleport(location);
+        return player.teleport(location);
+    }
+
+    private void runCompletion(Player player, boolean success, Runnable onComplete) {
+        if (!success || onComplete == null) return;
+
+        if (Bukkit.isPrimaryThread()) {
+            if (player.isOnline()) onComplete.run();
+            return;
+        }
+
+        Bukkit.getScheduler().runTask(VeltoPlugin.get(), () -> {
+            if (player.isOnline()) onComplete.run();
+        });
     }
 
     private int resolveCountdown(Player player) {

--- a/common/src/main/java/com/aven0x/Velto/managers/UserdataManager.java
+++ b/common/src/main/java/com/aven0x/Velto/managers/UserdataManager.java
@@ -70,23 +70,38 @@ public final class UserdataManager {
     }
 
     public static Object get(UUID uuid, String key) {
-        return getData(uuid).get(key);
+        YamlConfiguration yaml = getData(uuid);
+        synchronized (yaml) {
+            return yaml.get(key);
+        }
     }
 
     public static String getString(UUID uuid, String key, String def) {
-        return getData(uuid).getString(key, def);
+        YamlConfiguration yaml = getData(uuid);
+        synchronized (yaml) {
+            return yaml.getString(key, def);
+        }
     }
 
     public static int getInt(UUID uuid, String key, int def) {
-        return getData(uuid).getInt(key, def);
+        YamlConfiguration yaml = getData(uuid);
+        synchronized (yaml) {
+            return yaml.getInt(key, def);
+        }
     }
 
     public static boolean getBoolean(UUID uuid, String key, boolean def) {
-        return getData(uuid).getBoolean(key, def);
+        YamlConfiguration yaml = getData(uuid);
+        synchronized (yaml) {
+            return yaml.getBoolean(key, def);
+        }
     }
 
     public static void set(UUID uuid, String key, Object value) {
-        getData(uuid).set(key, value);
+        YamlConfiguration yaml = getData(uuid);
+        synchronized (yaml) {
+            yaml.set(key, value);
+        }
     }
 
     // === Persistence ===
@@ -103,7 +118,7 @@ public final class UserdataManager {
     public static void startAutosave(long intervalTicks) {
         if (autosaveTask != null) return;
         autosaveTask = VeltoPlugin.get().getServer().getScheduler()
-                .runTaskTimerAsynchronously(VeltoPlugin.get(), () -> {
+                .runTaskTimer(VeltoPlugin.get(), () -> {
                     for (Map.Entry<UUID, YamlConfiguration> entry : cache.entrySet()) {
                         YamlConfiguration snapshot = copyOf(entry.getValue());
                         enqueueSave(entry.getKey(), snapshot);
@@ -196,8 +211,10 @@ public final class UserdataManager {
 
     private static YamlConfiguration copyOf(YamlConfiguration source) {
         YamlConfiguration copy = new YamlConfiguration();
-        for (String key : source.getKeys(true)) {
-            copy.set(key, source.get(key));
+        synchronized (source) {
+            for (String key : source.getKeys(true)) {
+                copy.set(key, source.get(key));
+            }
         }
         return copy;
     }

--- a/paper/src/main/java/com/aven0x/VeltoPaper/managers/ChatManager.java
+++ b/paper/src/main/java/com/aven0x/VeltoPaper/managers/ChatManager.java
@@ -19,6 +19,8 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -37,15 +39,25 @@ public class ChatManager implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onChat(AsyncChatEvent event) {
         Player player = event.getPlayer();
-
         String rawMessage = LegacyComponentSerializer.legacySection().serialize(event.message());
-        if (AtMentionHandler.handle(player, rawMessage)) {
+
+        if (isAtMentionMessage(rawMessage)) {
             event.setCancelled(true);
+            runSync(() -> AtMentionHandler.handle(player, rawMessage));
             return;
         }
 
-        String format = resolveChatFormat(player);
+        String format = callSync(() -> buildChatFormat(player, rawMessage), CC.translate(ConfigUtil.getChatFormat())
+                .replace("%player_name%", player.getName())
+                .replace("%message%", rawMessage));
 
+        final String finalFormat = format;
+        event.renderer((source, displayName, message, viewer) ->
+                LegacyComponentSerializer.legacySection().deserialize(finalFormat));
+    }
+
+    private String buildChatFormat(Player player, String messageText) {
+        String format = resolveChatFormat(player);
         format = format.replace("%player_name%", player.getName());
 
         if (papiAvailable) {
@@ -53,14 +65,41 @@ public class ChatManager implements Listener {
             if (resolved != null) format = resolved;
         }
 
-        String messageText = LegacyComponentSerializer.legacySection().serialize(event.message());
         format = format.replace("%message%", messageText);
+        return CC.translate(format);
+    }
 
-        format = CC.translate(format);
+    private boolean isAtMentionMessage(String message) {
+        if (!message.startsWith("@")) return false;
+        int space = message.indexOf(' ');
+        return space > 1 && !message.substring(space + 1).trim().isEmpty();
+    }
 
-        final String finalFormat = format;
-        event.renderer((source, displayName, message, viewer) ->
-                LegacyComponentSerializer.legacySection().deserialize(finalFormat));
+    private void runSync(Runnable runnable) {
+        if (Bukkit.isPrimaryThread()) {
+            runnable.run();
+            return;
+        }
+
+        Bukkit.getScheduler().runTask(plugin, runnable);
+    }
+
+    private <T> T callSync(Callable<T> callable, T fallback) {
+        if (Bukkit.isPrimaryThread()) {
+            try {
+                return callable.call();
+            } catch (Exception e) {
+                plugin.getLogger().warning("[Velto] Failed to build chat format: " + e.getMessage());
+                return fallback;
+            }
+        }
+
+        try {
+            return Bukkit.getScheduler().callSyncMethod(plugin, callable).get(2, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            plugin.getLogger().warning("[Velto] Timed out while building chat format: " + e.getMessage());
+            return fallback;
+        }
     }
 
     private String resolveChatFormat(Player player) {

--- a/paper/src/main/resources/commands.yml
+++ b/paper/src/main/resources/commands.yml
@@ -124,9 +124,13 @@ tpa:
 tpaaccept:
   enabled: true
   aliases: ["tpaccept"]
+  permissions:
+    velto.tpa: velto.tpa
 tpadeny:
   enabled: true
   aliases: ["tpdeny"]
+  permissions:
+    velto.tpa: velto.tpa
 sudo:
   enabled: true
   aliases: []


### PR DESCRIPTION
### Motivation
- Ensure chat formatting and @-mention handling are safe when chat events fire off the main thread and avoid sync violations. 
- Make teleports fully async-aware so Paper's `teleportAsync` future is respected and completion callbacks run only after success. 
- Prevent concurrent access issues in userdata handling and make autosave scheduling deterministic. 
- Add permission checks for TPA accept/deny and allow `commands.yml` to be reloaded during runtime.

### Description
- Updated Bukkit and Paper `ChatManager` to build chat format on the main thread via new helpers `runSync(Runnable)` and `callSync(Callable<T>, T)` and to short-circuit @-mention messages earlier using `isAtMentionMessage(String)` so `AtMentionHandler.handle` runs on the main thread.  Message percent-escaping and PlaceholderAPI resolution are preserved and final format is translated with `CC.translate`.
- Paper `ChatManager` adapts same sync-safe format building and uses the Adventure legacy serializer for message extraction and renderer installation.
- `TeleportManager.teleportAsync` now returns `CompletableFuture<Boolean>` and attempts to call Paper's `teleportAsync` reflectively; it falls back to a synchronous bukkit teleport that returns success as a boolean, and completion handling is routed through `runCompletion` so `onComplete` runs only when teleport succeeds and the player is online.
- `UserdataManager` now synchronizes access to `YamlConfiguration` for `get`, `set`, and getters, synchronizes `copyOf` of configurations, and switches autosave scheduling to the main scheduler invocation that enqueues asynchronous save tasks; pending-save logic unchanged.
- Added permission checks (`velto.tpa`) to `TpaAcceptCommand` and `TpaDenyCommand` and added corresponding permissions entries to `commands.yml` for both Paper and Bukkit resources.
- `ReloadCommand` now tries to reload `commands.yml` by invoking `CommandUtil.load()` and logs success/failure.

### Testing
- Built the project and ran the automated build (`./gradlew build`) which completed successfully and unit tests in the project passed.
- Verified that existing unit tests and CI static checks ran during the build and reported green status.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a060f09c1d0832b9123a44113d4ee0f)