### PR TITLE
Introduce chat format cache, improve teleport async handling, userdata autosave batching, and permission tweaks

### DIFF
--- a/bukkit/src/main/java/com/aven0x/VeltoBukkit/managers/ChatManager.java
+++ b/bukkit/src/main/java/com/aven0x/VeltoBukkit/managers/ChatManager.java
@@ -1,13 +1,12 @@
 package com.aven0x.VeltoBukkit.managers;
 
+import com.aven0x.Velto.managers.ChatFormatCache;
 import com.aven0x.Velto.utils.AtMentionHandler;
 import com.aven0x.Velto.utils.ConfigUtil;
 import com.aven0x.Velto.utils.PlayerUtil;
 import com.aven0x.VeltoBukkit.VeltoBukkit;
 import me.clip.placeholderapi.PlaceholderAPI;
-import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -15,75 +14,62 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.scheduler.BukkitTask;
 
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 public class ChatManager implements Listener {
 
     private final VeltoBukkit plugin;
     private final boolean papiAvailable;
+    private BukkitTask refreshTask;
 
     public ChatManager(VeltoBukkit plugin) {
         this.plugin = plugin;
         this.papiAvailable = Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null;
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
+        startFormatRefreshTask();
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onChat(AsyncPlayerChatEvent event) {
         Player player = event.getPlayer();
+        String rawMessage = event.getMessage();
 
-        if (AtMentionHandler.handle(player, event.getMessage())) {
+        if (isAtMentionMessage(rawMessage)) {
             event.setCancelled(true);
+            runSync(() -> AtMentionHandler.handle(player, rawMessage));
             return;
         }
 
-        String format = resolveChatFormat(player);
-
-        format = format.replace("%player_name%", player.getName());
-
-        if (papiAvailable) {
-            String resolved = PlaceholderAPI.setPlaceholders(player, format);
-            if (resolved != null) format = resolved;
-        }
-
-        String safeMessage = event.getMessage().replace("%", "%%");
-        format = format.replace("%message%", safeMessage);
-
-        format = CC.translate(format);
-
-        event.setFormat(format);
+        String safeMessage = rawMessage.replace("%", "%%");
+        event.setFormat(ChatFormatCache.get(player).replace("%message%", safeMessage));
     }
 
-    private String resolveChatFormat(Player player) {
-        String fallback = ConfigUtil.getChatFormat();
+    private boolean isAtMentionMessage(String message) {
+        if (!message.startsWith("@")) return false;
+        int space = message.indexOf(' ');
+        return space > 1 && !message.substring(space + 1).trim().isEmpty();
+    }
 
-        List<String> priority = ConfigUtil.getChatPriority();
-        if (priority == null || priority.isEmpty()) {
-            return fallback;
+    private void runSync(Runnable runnable) {
+        if (Bukkit.isPrimaryThread()) {
+            runnable.run();
+            return;
         }
 
-        for (String group : priority) {
-            ConfigurationSection sec = ConfigUtil.getChatGroupSection(group);
-            if (sec == null) continue;
+        Bukkit.getScheduler().runTask(plugin, runnable);
+    }
 
-            String groupFormat = sec.getString("format", "");
-            if (groupFormat == null || groupFormat.isBlank()) continue;
-
-            String perm = sec.getString("permission", "");
-            if (perm != null && !perm.isBlank() && player.hasPermission(perm)) {
-                return groupFormat;
-            }
-        }
-
-        return fallback;
+    private void startFormatRefreshTask() {
+        if (refreshTask != null) return;
+        refreshTask = Bukkit.getScheduler().runTaskTimer(plugin, ChatFormatCache::refreshAll, 20L, 20L * 60L);
     }
 
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {
+        Bukkit.getScheduler().runTask(plugin, () -> ChatFormatCache.refresh(event.getPlayer()));
+
         if (PlayerUtil.isVanished(event.getPlayer())) {
             event.setJoinMessage(null);
             return;
@@ -97,11 +83,13 @@ public class ChatManager implements Listener {
             if (resolved != null) msg = resolved;
         }
 
-        event.setJoinMessage(CC.translate(msg));
+        event.setJoinMessage(ChatFormatCache.translate(msg));
     }
 
     @EventHandler
     public void onQuit(PlayerQuitEvent event) {
+        ChatFormatCache.remove(event.getPlayer().getUniqueId());
+
         if (PlayerUtil.isVanished(event.getPlayer())) {
             event.setQuitMessage(null);
             return;
@@ -115,25 +103,16 @@ public class ChatManager implements Listener {
             if (resolved != null) msg = resolved;
         }
 
-        event.setQuitMessage(CC.translate(msg));
+        event.setQuitMessage(ChatFormatCache.translate(msg));
     }
 
     public static class CC {
-        private static final Pattern HEX_PATTERN = Pattern.compile("&#[a-fA-F0-9]{6}");
-
         public static String translate(String input) {
-            if (input == null) return "";
-            Matcher matcher = HEX_PATTERN.matcher(input);
-            while (matcher.find()) {
-                String token = matcher.group();
-                String hex = token.substring(1);
-                input = input.replace(token, ChatColor.of(hex).toString());
-            }
-            return input.replace("&", "§");
+            return ChatFormatCache.translate(input);
         }
 
         public static List<String> translate(List<String> input) {
-            return input.stream().map(CC::translate).collect(Collectors.toList());
+            return ChatFormatCache.translate(input);
         }
     }
 }

--- a/bukkit/src/main/resources/commands.yml
+++ b/bukkit/src/main/resources/commands.yml
@@ -124,9 +124,13 @@ tpa:
 tpaaccept:
   enabled: true
   aliases: ["tpaccept"]
+  permissions:
+    velto.tpa: velto.tpa
 tpadeny:
   enabled: true
   aliases: ["tpdeny"]
+  permissions:
+    velto.tpa: velto.tpa
 sudo:
   enabled: true
   aliases: []

--- a/common/src/main/java/com/aven0x/Velto/commands/ReloadCommand.java
+++ b/common/src/main/java/com/aven0x/Velto/commands/ReloadCommand.java
@@ -1,5 +1,7 @@
 package com.aven0x.Velto.commands;
 
+import com.aven0x.Velto.managers.ChatFormatCache;
+import com.aven0x.Velto.utils.CommandUtil;
 import com.aven0x.Velto.utils.ConfigUtil;
 import com.aven0x.Velto.utils.LangUtil;
 import org.bukkit.Bukkit;
@@ -33,6 +35,22 @@ public class ReloadCommand extends BaseCommand {
             Bukkit.getLogger().info("[Velto] lang.yml reloaded.");
         } catch (Throwable t) {
             Bukkit.getLogger().severe("[Velto] Failed to reload lang.yml: " + t.getMessage());
+            t.printStackTrace();
+        }
+
+        try {
+            CommandUtil.load();
+            Bukkit.getLogger().info("[Velto] commands.yml reloaded.");
+        } catch (Throwable t) {
+            Bukkit.getLogger().severe("[Velto] Failed to reload commands.yml: " + t.getMessage());
+            t.printStackTrace();
+        }
+
+        try {
+            ChatFormatCache.refreshAll();
+            Bukkit.getLogger().info("[Velto] chat format cache refreshed.");
+        } catch (Throwable t) {
+            Bukkit.getLogger().severe("[Velto] Failed to refresh chat format cache: " + t.getMessage());
             t.printStackTrace();
         }
 

--- a/common/src/main/java/com/aven0x/Velto/commands/TpaAcceptCommand.java
+++ b/common/src/main/java/com/aven0x/Velto/commands/TpaAcceptCommand.java
@@ -20,6 +20,7 @@ public class TpaAcceptCommand extends BaseCommand {
     @Override
     public boolean execute(CommandSender sender, String label, String[] args) {
         if (!isPlayer(sender)) return true;
+        if (!hasPermission(sender, "velto.tpa")) return true;
 
         Player target = (Player) sender;
         TpaRequest request;

--- a/common/src/main/java/com/aven0x/Velto/commands/TpaDenyCommand.java
+++ b/common/src/main/java/com/aven0x/Velto/commands/TpaDenyCommand.java
@@ -19,6 +19,7 @@ public class TpaDenyCommand extends BaseCommand {
     @Override
     public boolean execute(CommandSender sender, String label, String[] args) {
         if (!isPlayer(sender)) return true;
+        if (!hasPermission(sender, "velto.tpa")) return true;
 
         Player target = (Player) sender;
         TpaRequest request;

--- a/common/src/main/java/com/aven0x/Velto/managers/ChatFormatCache.java
+++ b/common/src/main/java/com/aven0x/Velto/managers/ChatFormatCache.java
@@ -1,0 +1,96 @@
+package com.aven0x.Velto.managers;
+
+import com.aven0x.Velto.utils.ConfigUtil;
+import me.clip.placeholderapi.PlaceholderAPI;
+import net.md_5.bungee.api.ChatColor;
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class ChatFormatCache {
+
+    private static final Pattern HEX_PATTERN = Pattern.compile("&#[a-fA-F0-9]{6}");
+    private static final Map<UUID, String> cachedFormats = new ConcurrentHashMap<>();
+
+    private ChatFormatCache() {}
+
+    public static String get(Player player) {
+        return cachedFormats.computeIfAbsent(player.getUniqueId(), ignored -> buildFallbackFormat(player));
+    }
+
+    public static void refresh(Player player) {
+        cachedFormats.put(player.getUniqueId(), buildFormat(player));
+    }
+
+    public static void refreshAll() {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            refresh(player);
+        }
+    }
+
+    public static void remove(UUID uuid) {
+        cachedFormats.remove(uuid);
+    }
+
+    public static String translate(String input) {
+        if (input == null) return "";
+        Matcher matcher = HEX_PATTERN.matcher(input);
+        while (matcher.find()) {
+            String token = matcher.group();
+            String hex = token.substring(1);
+            input = input.replace(token, ChatColor.of(hex).toString());
+        }
+        return input.replace("&", "§");
+    }
+
+    public static List<String> translate(List<String> input) {
+        return input.stream().map(ChatFormatCache::translate).toList();
+    }
+
+    private static String buildFormat(Player player) {
+        String format = resolveChatFormat(player);
+        format = format.replace("%player_name%", player.getName());
+
+        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            String resolved = PlaceholderAPI.setPlaceholders(player, format);
+            if (resolved != null) format = resolved;
+        }
+
+        return translate(format);
+    }
+
+    private static String buildFallbackFormat(Player player) {
+        return translate(ConfigUtil.getChatFormat()).replace("%player_name%", player.getName());
+    }
+
+    private static String resolveChatFormat(Player player) {
+        String fallback = ConfigUtil.getChatFormat();
+
+        List<String> priority = ConfigUtil.getChatPriority();
+        if (priority == null || priority.isEmpty()) {
+            return fallback;
+        }
+
+        for (String group : priority) {
+            ConfigurationSection sec = ConfigUtil.getChatGroupSection(group);
+            if (sec == null) continue;
+
+            String groupFormat = sec.getString("format", "");
+            if (groupFormat == null || groupFormat.isBlank()) continue;
+
+            String perm = sec.getString("permission", "");
+            if (perm != null && !perm.isBlank() && player.hasPermission(perm)) {
+                return groupFormat;
+            }
+        }
+
+        return fallback;
+    }
+}

--- a/common/src/main/java/com/aven0x/Velto/managers/TeleportManager.java
+++ b/common/src/main/java/com/aven0x/Velto/managers/TeleportManager.java
@@ -10,8 +10,10 @@ import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 
+import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class TeleportManager {
@@ -32,16 +34,15 @@ public class TeleportManager {
         teleport(player, location, null);
     }
 
-    // Player-initiated teleport with an optional callback executed the moment
-    // the actual teleport fires (end of countdown or instant when delay == 0).
+    // Player-initiated teleport with an optional callback executed after the
+    // teleport completes successfully.
     public void teleport(Player player, Location location, Runnable onComplete) {
         cancelPending(player);
 
         int seconds = resolveCountdown(player);
 
         if (seconds <= 0) {
-            teleportAsync(player, location);
-            if (onComplete != null) onComplete.run();
+            teleportAsync(player, location).thenAccept(success -> runCompletion(player, success, onComplete));
             return;
         }
 
@@ -68,8 +69,7 @@ public class TeleportManager {
                 if (remaining <= 0) {
                     pendingTeleports.remove(player.getUniqueId());
                     this.cancel();
-                    teleportAsync(player, location);
-                    if (onComplete != null) onComplete.run();
+                    teleportAsync(player, location).thenAccept(success -> runCompletion(player, success, onComplete));
                     return;
                 }
 
@@ -82,17 +82,20 @@ public class TeleportManager {
     }
 
     // System/admin teleport: bypasses countdown entirely (AFK zone, /tpall, etc.)
-    public void teleportAsync(Player player, Location location) {
+    public CompletableFuture<Boolean> teleportAsync(Player player, Location location) {
         if (ServerUtil.isPaper()) {
             try {
-                player.getClass().getMethod("teleportAsync", Location.class).invoke(player, location);
+                Method method = player.getClass().getMethod("teleportAsync", Location.class);
+                Object result = method.invoke(player, location);
+                if (result instanceof CompletableFuture<?> future) {
+                    return future.thenApply(Boolean.class::cast);
+                }
             } catch (Exception e) {
                 Bukkit.getLogger().warning("[Velto] teleportAsync failed on Paper, falling back to sync chunk load: " + e.getMessage());
-                bukkitTeleport(player, location);
             }
-        } else {
-            bukkitTeleport(player, location);
         }
+
+        return CompletableFuture.completedFuture(bukkitTeleport(player, location));
     }
 
     // Cancels any pending countdown for the given player.
@@ -101,9 +104,23 @@ public class TeleportManager {
         if (task != null) task.cancel();
     }
 
-    private void bukkitTeleport(Player player, Location location) {
+    private boolean bukkitTeleport(Player player, Location location) {
+        if (location.getWorld() == null) return false;
         location.getWorld().getChunkAt(location);
-        player.teleport(location);
+        return player.teleport(location);
+    }
+
+    private void runCompletion(Player player, boolean success, Runnable onComplete) {
+        if (!success || onComplete == null) return;
+
+        if (Bukkit.isPrimaryThread()) {
+            if (player.isOnline()) onComplete.run();
+            return;
+        }
+
+        Bukkit.getScheduler().runTask(VeltoPlugin.get(), () -> {
+            if (player.isOnline()) onComplete.run();
+        });
     }
 
     private int resolveCountdown(Player player) {

--- a/common/src/main/java/com/aven0x/Velto/managers/UserdataManager.java
+++ b/common/src/main/java/com/aven0x/Velto/managers/UserdataManager.java
@@ -7,7 +7,10 @@ import org.bukkit.scheduler.BukkitTask;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
@@ -17,12 +20,16 @@ public final class UserdataManager {
 
     private UserdataManager() {}
 
+    private static final int AUTOSAVE_BATCH_SIZE = 10;
+
     private static final Map<UUID, YamlConfiguration> cache = new ConcurrentHashMap<>();
     private static final Map<UUID, PendingSave> pendingSaves = new ConcurrentHashMap<>();
+    private static final Set<UUID> dirtyUsers = ConcurrentHashMap.newKeySet();
     private static File userdataFolder;
     private static Logger logger;
     private static volatile boolean initialized = false;
     private static BukkitTask autosaveTask = null;
+    private static BukkitTask autosaveFlushTask = null;
 
     private static final class PendingSave {
         YamlConfiguration snapshot;
@@ -70,45 +77,51 @@ public final class UserdataManager {
     }
 
     public static Object get(UUID uuid, String key) {
-        return getData(uuid).get(key);
+        YamlConfiguration yaml = getData(uuid);
+        synchronized (yaml) {
+            return yaml.get(key);
+        }
     }
 
     public static String getString(UUID uuid, String key, String def) {
-        return getData(uuid).getString(key, def);
+        YamlConfiguration yaml = getData(uuid);
+        synchronized (yaml) {
+            return yaml.getString(key, def);
+        }
     }
 
     public static int getInt(UUID uuid, String key, int def) {
-        return getData(uuid).getInt(key, def);
+        YamlConfiguration yaml = getData(uuid);
+        synchronized (yaml) {
+            return yaml.getInt(key, def);
+        }
     }
 
     public static boolean getBoolean(UUID uuid, String key, boolean def) {
-        return getData(uuid).getBoolean(key, def);
+        YamlConfiguration yaml = getData(uuid);
+        synchronized (yaml) {
+            return yaml.getBoolean(key, def);
+        }
     }
 
     public static void set(UUID uuid, String key, Object value) {
-        getData(uuid).set(key, value);
+        YamlConfiguration yaml = getData(uuid);
+        synchronized (yaml) {
+            yaml.set(key, value);
+        }
+        dirtyUsers.add(uuid);
     }
 
     // === Persistence ===
 
     public static void save(UUID uuid) {
-        if (!initialized) return;
-        YamlConfiguration yaml = cache.get(uuid);
-        if (yaml == null) return;
-
-        YamlConfiguration snapshot = copyOf(yaml);
-        enqueueSave(uuid, snapshot);
+        saveSnapshot(uuid, true);
     }
 
     public static void startAutosave(long intervalTicks) {
         if (autosaveTask != null) return;
         autosaveTask = VeltoPlugin.get().getServer().getScheduler()
-                .runTaskTimerAsynchronously(VeltoPlugin.get(), () -> {
-                    for (Map.Entry<UUID, YamlConfiguration> entry : cache.entrySet()) {
-                        YamlConfiguration snapshot = copyOf(entry.getValue());
-                        enqueueSave(entry.getKey(), snapshot);
-                    }
-                }, intervalTicks, intervalTicks);
+                .runTaskTimer(VeltoPlugin.get(), UserdataManager::flushDirtyUsers, intervalTicks, intervalTicks);
     }
 
     public static void stopAutosave() {
@@ -116,14 +129,20 @@ public final class UserdataManager {
             autosaveTask.cancel();
             autosaveTask = null;
         }
+        if (autosaveFlushTask != null) {
+            autosaveFlushTask.cancel();
+            autosaveFlushTask = null;
+        }
     }
 
     // Synchronous — call only from onDisable where async tasks won't run.
     public static void saveAll() {
         if (!initialized) return;
+        dirtyUsers.clear();
         for (Map.Entry<UUID, YamlConfiguration> entry : cache.entrySet()) {
             try {
-                entry.getValue().save(fileFor(entry.getKey()));
+                YamlConfiguration snapshot = copyOf(entry.getValue());
+                snapshot.save(fileFor(entry.getKey()));
                 pendingSaves.remove(entry.getKey());
             } catch (IOException e) {
                 logger.log(Level.SEVERE, "[Velto] Failed to save userdata for " + entry.getKey() + " on shutdown", e);
@@ -135,6 +154,42 @@ public final class UserdataManager {
 
     private static File fileFor(UUID uuid) {
         return new File(userdataFolder, uuid.toString() + ".yml");
+    }
+
+    private static void flushDirtyUsers() {
+        if (autosaveFlushTask != null || dirtyUsers.isEmpty()) return;
+
+        List<UUID> users = new ArrayList<>(dirtyUsers);
+        autosaveFlushTask = VeltoPlugin.get().getServer().getScheduler().runTaskTimer(VeltoPlugin.get(), new Runnable() {
+            private int index = 0;
+
+            @Override
+            public void run() {
+                int processed = 0;
+                while (index < users.size() && processed < AUTOSAVE_BATCH_SIZE) {
+                    UUID uuid = users.get(index++);
+                    if (dirtyUsers.remove(uuid)) {
+                        saveSnapshot(uuid, false);
+                    }
+                    processed++;
+                }
+
+                if (index >= users.size()) {
+                    autosaveFlushTask.cancel();
+                    autosaveFlushTask = null;
+                }
+            }
+        }, 0L, 1L);
+    }
+
+    private static void saveSnapshot(UUID uuid, boolean clearDirty) {
+        if (!initialized) return;
+        YamlConfiguration yaml = cache.get(uuid);
+        if (yaml == null) return;
+
+        if (clearDirty) dirtyUsers.remove(uuid);
+        YamlConfiguration snapshot = copyOf(yaml);
+        enqueueSave(uuid, snapshot);
     }
 
     private static void enqueueSave(UUID uuid, YamlConfiguration snapshot) {
@@ -196,8 +251,10 @@ public final class UserdataManager {
 
     private static YamlConfiguration copyOf(YamlConfiguration source) {
         YamlConfiguration copy = new YamlConfiguration();
-        for (String key : source.getKeys(true)) {
-            copy.set(key, source.get(key));
+        synchronized (source) {
+            for (String key : source.getKeys(true)) {
+                copy.set(key, source.get(key));
+            }
         }
         return copy;
     }

--- a/paper/src/main/java/com/aven0x/VeltoPaper/managers/ChatManager.java
+++ b/paper/src/main/java/com/aven0x/VeltoPaper/managers/ChatManager.java
@@ -1,94 +1,77 @@
 package com.aven0x.VeltoPaper.managers;
 
+import com.aven0x.Velto.managers.ChatFormatCache;
 import com.aven0x.Velto.utils.AtMentionHandler;
 import com.aven0x.Velto.utils.ConfigUtil;
 import com.aven0x.Velto.utils.PlayerUtil;
 import com.aven0x.VeltoPaper.VeltoPaper;
 import io.papermc.paper.event.player.AsyncChatEvent;
-
 import me.clip.placeholderapi.PlaceholderAPI;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
-import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.scheduler.BukkitTask;
 
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 public class ChatManager implements Listener {
 
     private final VeltoPaper plugin;
     private final boolean papiAvailable;
+    private BukkitTask refreshTask;
 
     public ChatManager(VeltoPaper plugin) {
         this.plugin = plugin;
         this.papiAvailable = Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null;
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
+        startFormatRefreshTask();
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onChat(AsyncChatEvent event) {
         Player player = event.getPlayer();
-
         String rawMessage = LegacyComponentSerializer.legacySection().serialize(event.message());
-        if (AtMentionHandler.handle(player, rawMessage)) {
+
+        if (isAtMentionMessage(rawMessage)) {
             event.setCancelled(true);
+            runSync(() -> AtMentionHandler.handle(player, rawMessage));
             return;
         }
 
-        String format = resolveChatFormat(player);
-
-        format = format.replace("%player_name%", player.getName());
-
-        if (papiAvailable) {
-            String resolved = PlaceholderAPI.setPlaceholders(player, format);
-            if (resolved != null) format = resolved;
-        }
-
-        String messageText = LegacyComponentSerializer.legacySection().serialize(event.message());
-        format = format.replace("%message%", messageText);
-
-        format = CC.translate(format);
-
-        final String finalFormat = format;
+        String finalFormat = ChatFormatCache.get(player).replace("%message%", rawMessage);
         event.renderer((source, displayName, message, viewer) ->
                 LegacyComponentSerializer.legacySection().deserialize(finalFormat));
     }
 
-    private String resolveChatFormat(Player player) {
-        String fallback = ConfigUtil.getChatFormat();
+    private boolean isAtMentionMessage(String message) {
+        if (!message.startsWith("@")) return false;
+        int space = message.indexOf(' ');
+        return space > 1 && !message.substring(space + 1).trim().isEmpty();
+    }
 
-        List<String> priority = ConfigUtil.getChatPriority();
-        if (priority == null || priority.isEmpty()) {
-            return fallback;
+    private void runSync(Runnable runnable) {
+        if (Bukkit.isPrimaryThread()) {
+            runnable.run();
+            return;
         }
 
-        for (String group : priority) {
-            ConfigurationSection sec = ConfigUtil.getChatGroupSection(group);
-            if (sec == null) continue;
+        Bukkit.getScheduler().runTask(plugin, runnable);
+    }
 
-            String groupFormat = sec.getString("format", "");
-            if (groupFormat == null || groupFormat.isBlank()) continue;
-
-            String perm = sec.getString("permission", "");
-            if (perm != null && !perm.isBlank() && player.hasPermission(perm)) {
-                return groupFormat;
-            }
-        }
-
-        return fallback;
+    private void startFormatRefreshTask() {
+        if (refreshTask != null) return;
+        refreshTask = Bukkit.getScheduler().runTaskTimer(plugin, ChatFormatCache::refreshAll, 20L, 20L * 60L);
     }
 
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {
+        Bukkit.getScheduler().runTask(plugin, () -> ChatFormatCache.refresh(event.getPlayer()));
+
         if (PlayerUtil.isVanished(event.getPlayer())) {
             event.setJoinMessage(null);
             return;
@@ -102,11 +85,13 @@ public class ChatManager implements Listener {
             if (resolved != null) msg = resolved;
         }
 
-        event.setJoinMessage(CC.translate(msg));
+        event.setJoinMessage(ChatFormatCache.translate(msg));
     }
 
     @EventHandler
     public void onQuit(PlayerQuitEvent event) {
+        ChatFormatCache.remove(event.getPlayer().getUniqueId());
+
         if (PlayerUtil.isVanished(event.getPlayer())) {
             event.setQuitMessage(null);
             return;
@@ -120,25 +105,16 @@ public class ChatManager implements Listener {
             if (resolved != null) msg = resolved;
         }
 
-        event.setQuitMessage(CC.translate(msg));
+        event.setQuitMessage(ChatFormatCache.translate(msg));
     }
 
     public static class CC {
-        private static final Pattern HEX_PATTERN = Pattern.compile("&#[a-fA-F0-9]{6}");
-
         public static String translate(String input) {
-            if (input == null) return "";
-            Matcher matcher = HEX_PATTERN.matcher(input);
-            while (matcher.find()) {
-                String token = matcher.group();
-                String hex = token.substring(1);
-                input = input.replace(token, ChatColor.of(hex).toString());
-            }
-            return input.replace("&", "§");
+            return ChatFormatCache.translate(input);
         }
 
         public static List<String> translate(List<String> input) {
-            return input.stream().map(CC::translate).collect(Collectors.toList());
+            return ChatFormatCache.translate(input);
         }
     }
 }

--- a/paper/src/main/resources/commands.yml
+++ b/paper/src/main/resources/commands.yml
@@ -124,9 +124,13 @@ tpa:
 tpaaccept:
   enabled: true
   aliases: ["tpaccept"]
+  permissions:
+    velto.tpa: velto.tpa
 tpadeny:
   enabled: true
   aliases: ["tpdeny"]
+  permissions:
+    velto.tpa: velto.tpa
 sudo:
   enabled: true
   aliases: []


### PR DESCRIPTION
### Motivation
- Reduce chat-format computation overhead by caching resolved formats and centralizing translation logic.  
- Make teleports fully asynchronous with reliable completion callbacks and safer Paper integration.  
- Improve userdata persistence by batching autosave work and making in-memory userdata access thread-safe.  
- Tighten TPA command permissions and ensure `commands.yml` and caches reload during runtime reloads.  

### Description
- Add `ChatFormatCache` to `common` to build, cache, translate, and periodically refresh player chat formats, and reuse it from Bukkit and Paper `ChatManager` implementations.  
- Refactor `ChatManager` (Bukkit and Paper) to use `ChatFormatCache`, add mention detection (`isAtMentionMessage`), a `runSync` helper, and a periodic refresh task that refreshes cached formats; join/quit messages now use `ChatFormatCache.translate`.  
- Add `ChatFormatCache.refreshAll()` invocation and `CommandUtil.load()` to `ReloadCommand` so `commands.yml` and chat cache are refreshed on reload.  
- Change `TeleportManager.teleportAsync` to return `CompletableFuture<Boolean>`, use reflection to handle Paper's `teleportAsync` future result, make the synchronous fallback return success boolean, and add `runCompletion` to run `onComplete` only when teleport succeeded and player is online.  
- Rework `UserdataManager` for thread-safety and autosave efficiency by synchronizing access to `YamlConfiguration`, tracking dirty users, batching autosave flushes (`AUTOSAVE_BATCH_SIZE`), and simplifying save lifecycle with `saveSnapshot` and a flush task.  
- Add permission checks to `TpaAcceptCommand` and `TpaDenyCommand` (`velto.tpa`) and add matching permissions entries to `commands.yml` for both Bukkit and Paper resources.  
- Replace legacy in-class color/hex translation utilities with delegations to `ChatFormatCache.translate` in ChatManager CC helpers.  

### Testing
- Performed a full project build with `./gradlew build` which completed successfully.  
- Ran automated unit tests with `./gradlew test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a060f09c1d0832b9123a44113d4ee0f)